### PR TITLE
Update 'Add wikiInfo' script files

### DIFF
--- a/project/appendWikiElements.py
+++ b/project/appendWikiElements.py
@@ -84,15 +84,16 @@ def getAutoBlueprintsAppend(autoBlueprints: ET.Element) -> str:
         <mod:setAttributes fullURL="https://ftlmultiverse.fandom.com/wiki/{wikiRedirect.replace(' ', '_')}"/>
     </mod:findName>'''
 
-    # Add autoBlueprints with wikiPages
-    # this takes 4 seconds
+    # Add blueprintLists with wikiPages to autoBlueprints.xml.append
+    #   Enables script to use blueprintLists along with wikiElements
+    # Takes ~4 seconds
     bpLists = autoBlueprints.findall('.//blueprintList[@wikiPage]')
-    bpListString = []
+    bpListStringList = []
     for bpList in bpLists:
-        string = ET.tostring(bpList, encoding='utf-8').decode()
-        bpListString.append(string)
+        bpListString = ET.tostring(bpList, encoding='utf-8').decode()
+        bpListStringList.append(bpListString)
 
-    autoBlueprintsAppend += '\n'.join(bpListString)
+    autoBlueprintsAppend += '\n'.join(bpListStringList)
     return autoBlueprintsAppend
 
 def writeXMLAppendFile(fileName: str, fileText: str):

--- a/project/appendWikiElements.py
+++ b/project/appendWikiElements.py
@@ -83,6 +83,16 @@ def getAutoBlueprintsAppend(autoBlueprints: ET.Element) -> str:
         <mod:setAttributes wikiLink="{wikiLink}"/>
         <mod:setAttributes fullURL="https://ftlmultiverse.fandom.com/wiki/{wikiRedirect.replace(' ', '_')}"/>
     </mod:findName>'''
+
+    # Add autoBlueprints with wikiPages
+    # this takes 4 seconds
+    bpLists = autoBlueprints.findall('.//blueprintList[@wikiPage]')
+    bpListString = []
+    for bpList in bpLists:
+        string = ET.tostring(bpList, encoding='utf-8').decode()
+        bpListString.append(string)
+
+    autoBlueprintsAppend += '\n'.join(bpListString)
     return autoBlueprintsAppend
 
 def writeXMLAppendFile(fileName: str, fileText: str):

--- a/project/blueprintUtils.py
+++ b/project/blueprintUtils.py
@@ -67,6 +67,16 @@ def findBlueprint(rootElement: ET.Element, searchTag: str, blueprintName: str) -
         raise Exception(f'Blueprint not found: {blueprintName}')
     return blueprint
 
+# Gets blueprint found in blueprints.xml or dlcBlueprints.xml
+def getNormalBlueprint(path: str) -> ET.Element:
+    blueprint = blueprints.find(path)
+    if blueprint is None:
+        blueprint = dlcBlueprints.find(path)
+
+    if blueprint is None:
+        raise Exception(f'Invalid blueprintPath: {path}')
+    return blueprint
+
 def createWikiRedirect(wikiPage: str, wikiHeading: str) -> str:
     # remove brackets from drones and player weapons
     wikiHeading = removeBracketsFromTitle(wikiHeading)

--- a/project/blueprintUtils.py
+++ b/project/blueprintUtils.py
@@ -127,16 +127,11 @@ def getTitle(blueprint: ET.Element) -> str:
         title = titleElement.text    
     else: 
         id = titleElement.get('id')
-        # title in text_blueprints
+        # title in textBlueprints
         textBlueprint = textBlueprints.find(f'.//text[@name="{id}"]')
-
         if textBlueprint is None:
-            blueprintName = blueprint.get('name')
-            raise Exception(f'Unhanded blueprint relying on id: blueprint: {blueprintName}') 
+            raise Exception(f'Unhanded blueprint relying on id: blueprint: {blueprint.get("name")}') 
         title = textBlueprint.text
-
-    title = removeBracketsFromTitle(title)
-    return title
 
     title = removeBracketsFromTitle(title)
     return title

--- a/project/blueprintUtils.py
+++ b/project/blueprintUtils.py
@@ -115,8 +115,18 @@ def getTitle(blueprint: ET.Element) -> str:
     # if it has an 'id' attribute, access it from text_blueprints.xml
     if not titleElement.get('id'):
         title = titleElement.text    
-    else:
-        raise Exception(f'blueprint relying on id: {blueprint.get("name")}')
+    else: 
+        id = titleElement.get('id')
+        # title in text_blueprints
+        textBlueprint = textBlueprints.find(f'.//text[@name="{id}"]')
+
+        if textBlueprint is None:
+            blueprintName = blueprint.get('name')
+            raise Exception(f'Unhanded blueprint relying on id: blueprint: {blueprintName}') 
+        title = textBlueprint.text
+
+    title = removeBracketsFromTitle(title)
+    return title
 
     title = removeBracketsFromTitle(title)
     return title

--- a/project/blueprintUtils.py
+++ b/project/blueprintUtils.py
@@ -128,8 +128,8 @@ def getTitle(blueprint: ET.Element) -> str:
         title = titleElement.text    
     else: 
         id = titleElement.get('id')
-        # title in textBlueprints
-        textBlueprint = textBlueprints.find(f'.//text[@name="{id}"]')
+        # title in text_blueprints
+        textBlueprint = text_blueprints.find(f'.//text[@name="{id}"]')
         if textBlueprint is None:
             raise Exception(f'Unhanded blueprint relying on id: blueprint: {blueprint.get("name")}') 
         title = textBlueprint.text
@@ -262,4 +262,4 @@ def purgeDLCBlueprints(blueprintsText: str) -> str:
 blueprints = getBlueprints()
 dlcBlueprints =  getDLCBlueprints()
 autoBlueprints = ET.parse(pathToData + 'autoBlueprints.xml').getroot()
-textBlueprints = ET.parse(pathToData + 'text_blueprints.xml').getroot()
+text_blueprints = ET.parse(pathToData + 'text_blueprints.xml').getroot()

--- a/project/blueprintUtils.py
+++ b/project/blueprintUtils.py
@@ -68,6 +68,7 @@ def findBlueprint(rootElement: ET.Element, searchTag: str, blueprintName: str) -
     return blueprint
 
 # Gets blueprint found in blueprints.xml or dlcBlueprints.xml
+# FIXME: this method name isn't descriptive
 def getNormalBlueprint(path: str) -> ET.Element:
     blueprint = blueprints.find(path)
     if blueprint is None:

--- a/project/blueprintUtils.py
+++ b/project/blueprintUtils.py
@@ -2,6 +2,9 @@ import xml.etree.ElementTree as ET
 import re
 import os
 
+# Contains various functions, variables, and sets for other files to use.
+# FIXME: the name of this file isn't descriptive
+
 cwd = os.path.dirname(os.path.abspath(__file__))
 pathToData = os.path.join(cwd,'FTL DAT/data/')
 wikiElementsPath = cwd + '\\Append wikiElements\\data\\'

--- a/project/blueprintUtils.py
+++ b/project/blueprintUtils.py
@@ -205,6 +205,7 @@ def processText(text: str) -> str:
     text = text.replace('™', '↑')
     return text
 
+# exclude text between startText and endText
 def replaceText(blueprintsText: str, startText: str, endText: str) -> str:
     startIndex = blueprintsText.find(startText)
     endIndex = blueprintsText.find(endText)
@@ -245,3 +246,4 @@ def purgeDLCBlueprints(blueprintsText: str) -> str:
 blueprints = getBlueprints()
 dlcBlueprints =  getDLCBlueprints()
 autoBlueprints = ET.parse(pathToData + 'autoBlueprints.xml').getroot()
+textBlueprints = ET.parse(pathToData + 'text_blueprints.xml').getroot()

--- a/project/shipExport.py
+++ b/project/shipExport.py
@@ -34,13 +34,13 @@ class Ship:
 
     # opening files once and passing instead of opening them many times
     # significantly reduces runtime
-    def __init__(self, blueprint, blueprints, hyperspace, text_blueprints, events_boss):
+    def __init__(self, blueprint, blueprints, hyperspace, events_boss):
         self.blueprint = blueprint
         self.blueprints = blueprints
         self.blueprintName = self.blueprint.get('name')
 
         self.hyperspace = hyperspace
-        self.text_blueprints = text_blueprints
+        self.text_blueprints = blueprintUtils.textBlueprints
         self.events_boss = events_boss
         customShipPath = f'.//ships/customShip[@name="{self.blueprintName}"]'
         self.customShip = hyperspace.find(customShipPath)

--- a/project/shipExport.py
+++ b/project/shipExport.py
@@ -40,7 +40,7 @@ class Ship:
         self.blueprintName = self.blueprint.get('name')
 
         self.hyperspace = hyperspace
-        self.text_blueprints = blueprintUtils.textBlueprints
+        self.text_blueprints = blueprintUtils.text_blueprints
         self.events_boss = events_boss
         customShipPath = f'.//ships/customShip[@name="{self.blueprintName}"]'
         self.customShip = hyperspace.find(customShipPath)

--- a/project/wikiShipExport.py
+++ b/project/wikiShipExport.py
@@ -15,7 +15,6 @@ errorShips = {
 def getWikiShipText() -> str:
     blueprints = blueprintUtils.getBlueprints()
     hyperspace = ET.parse(blueprintUtils.pathToData + 'hyperspace.xml').getroot()
-    text_blueprints = ET.parse(blueprintUtils.pathToData + 'text_blueprints.xml').getroot()
     events_boss = ET.parse(blueprintUtils.pathToData + 'events_boss.xml').getroot()
 
     shipPath = './/shipBlueprint[@name]'
@@ -37,7 +36,7 @@ def getWikiShipText() -> str:
             wikiShipText += f'\n{currWikiPage}\n'
 
         #print(blueprintName)
-        ship = Ship(shipBlueprint, blueprints, hyperspace, text_blueprints, events_boss)
+        ship = Ship(shipBlueprint, blueprints, hyperspace, events_boss)
         wikiShipText += ship.toString() + '\n'
     return wikiShipText
 


### PR DESCRIPTION
- appendWikiElements.py
  - add blueprintLists with 'wikiPage' attribute to autoBlueprints.xml.append
    - enables scripts to use the blueprintLists when exporting lists of items on a page on the Wiki
    - increases runtime by ~4s 
- blueprintUtils.py
  - allow scripts after wikiElements have been appended to game files to access the <title>.id of a blueprintUtils:
    - re-add 'id' logic branch to getTitle() method
    - add text_blueprints variable for reading from text_blueprints.xml
  - add getNormalBlueprint() method for blueprints found in blueprints.xml or dlcBlueprints.xml
- wikiShipExport.py, shipExport.py
  - use text_blueprints from blueprintUtils.py (more efficient)
  